### PR TITLE
Fixed loading when missing deps and a config already exists

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = "Pulsar"
 gradle.ext {
     pulsar_mod_version = '0.3.0'
-    pulsar_mc_ver = '1.7.2'
-    pulsar_forge_ver = '10.12.1.1073'
+    pulsar_mc_ver = '1.7.10'
+    pulsar_forge_ver = '10.13.0.1180'
 }

--- a/src/main/java/io/drakon/pulsar/control/PulseManager.java
+++ b/src/main/java/io/drakon/pulsar/control/PulseManager.java
@@ -97,7 +97,7 @@ public class PulseManager {
         }
 
         String id, description, deps;
-        boolean forced, enabled;
+        boolean forced, enabled, missingDeps = false;
 
         try {
             Pulse p = pulse.getClass().getAnnotation(Pulse.class);
@@ -118,6 +118,7 @@ public class PulseManager {
             for (String s : parsedDeps) {
                 if (!Loader.isModLoaded(s)) {
                     log.info("Skipping Pulse " + id + "; missing dependency: " + s);
+                    missingDeps = true;
                     enabled = false;
                     break;
                 }
@@ -125,7 +126,7 @@ public class PulseManager {
         }
 
         PulseMeta meta = new PulseMeta(id, description, forced, enabled);
-        meta.setEnabled(getEnabledFromConfig(meta));
+        meta.setEnabled(!missingDeps && getEnabledFromConfig(meta));
 
         if (meta.isEnabled()) {
             parseAndAddProxies(pulse);


### PR DESCRIPTION
Let me explain what was happening first: (For the purposes of this, I will be referring to Forge's config system as the "config", as that is where I found the issue).
1. Upon loading the mod that uses Pulsar first and no config existed, one was created, and was written all the pulses and their default values. If the pulse was missing mods, it would write the default value as false. Otherwise, it would write true. This is as expected.
2. I then remove/add mods that would satisfy previously disabled pulses, and would unsatisfy previously enabled pulses. Not thinking about it, I don't go through and change the pulse config to make it work with my new mod arrangement. I can't imagine most end users would remember to do that, or even know that the file existed.
3. I then reboot Minecraft. In the log, Pulsar correctly identifies the pulses that have unsatisfied dependencies, and marks them as `enabled = false` in code. This is as expected.
4. The problem comes in here. It would then ask the config whether or not the pulse should be enabled. It does get the default value from the PulseMeta, but it doesn't matter, as that only applies if there isn't a value there or if there is an invalid value there. It will still read from the config the values from my first run, completely disregarding the fact that Pulsar has identified certain pulses as unable to run because of missing mods.

Obviously, this can be fixed on the end of the person with the `IConfiguration` implementation. However, it's probably better for Pulsar to **_not**_ ask the configs if a certain pulse should be enabled if they've identified that it doesn't have the mods to run. That's what I've done.

In my fix, when Pulsar identifies a pulse as unable to load because of missing mods, it enables a new flag (`missingDeps`). When it gets to `meta.setEnabled(`, it first checks if there are no missingDeps. If there is, it disables the pulse without asking the config. If there isn't any missing deps, it then asks the config if it should load the pulse.

That is the entirety of it.
